### PR TITLE
Adds new header option "enableScanInQuery" and removes JPath query

### DIFF
--- a/pydocumentdb/base.py
+++ b/pydocumentdb/base.py
@@ -80,6 +80,10 @@ def GetHeaders(document_client,
         headers[http_constants.HttpHeaders.SessionToken] = (
             options['sessionToken'])
 
+    if options.get('enableScanInQuery'):
+        headers[http_constants.HttpHeaders.EnableScanInQuery] = (
+            options['enableScanInQuery'])
+
     if options.get('resourceTokenExpirySeconds'):
         headers[http_constants.HttpHeaders.ResourceTokenExpiry] = (
             options['resourceTokenExpirySeconds'])

--- a/pydocumentdb/document_client.py
+++ b/pydocumentdb/document_client.py
@@ -1080,11 +1080,12 @@ class DocumentClient(object):
         url_connection = self.url_connection
         path = '/' + media_link
         media_id = base.GetIdFromLink(media_link)
+        attachment_id = base.GetAttachmentIdFromMediaId(media_id)
         headers = base.GetHeaders(self,
                                   initial_headers,
                                   'put',
                                   path,
-                                  media_id,
+                                  attachment_id,
                                   'media',
                                   options)
 
@@ -1636,31 +1637,17 @@ class DocumentClient(object):
             return __GetBodiesFromQueryResult(result)
         else:
             initial_headers[http_constants.HttpHeaders.IsQuery] = 'true'
-            if options.get('jpath'):
-                initial_headers[http_constants.HttpHeaders.Query] = query
-                headers = base.GetHeaders(self,
-                                          initial_headers,
-                                          'get',
-                                          path,
-                                          id,
-                                          type,
-                                          options)
-                result, self.last_response_headers = self.__Get(url_connection,
-                                                                path,
-                                                                headers)
-                return __GetBodiesFromQueryResult(result)
-            else:
-                initial_headers[http_constants.HttpHeaders.ContentType] = (
-                    runtime_constants.MediaTypes.SQL)
-                headers = base.GetHeaders(self,
-                                          initial_headers,
-                                          'post',
-                                          path,
-                                          id,
-                                          type,
-                                          options)
-                result, self.last_response_headers = self.__Post(url_connection,
-                                                                 path,
-                                                                 query,
-                                                                 headers)
-                return __GetBodiesFromQueryResult(result)
+            initial_headers[http_constants.HttpHeaders.ContentType] = (
+                runtime_constants.MediaTypes.SQL)
+            headers = base.GetHeaders(self,
+                                      initial_headers,
+                                      'post',
+                                      path,
+                                      id,
+                                      type,
+                                      options)
+            result, self.last_response_headers = self.__Post(url_connection,
+                                                             path,
+                                                             query,
+                                                             headers)
+            return __GetBodiesFromQueryResult(result)

--- a/pydocumentdb/http_constants.py
+++ b/pydocumentdb/http_constants.py
@@ -88,6 +88,8 @@ class HttpHeaders:
     RetryAfterInMilliseconds = 'x-ms-retry-after-ms'
     IsFeedUnfiltered = 'x-ms-is-feed-unfiltered'
     ResourceTokenExpiry = 'x-ms-documentdb-expiry-seconds'
+    EnableScanInQuery = 'x-ms-documentdb-query-enable-scan'
+    EmitVerboseTracesInQuery = 'x-ms-documentdb-query-emit-traces'
 
     # Quota Info
     MaxEntityCount = 'x-ms-root-entity-max-count'

--- a/python.pyproj
+++ b/python.pyproj
@@ -20,7 +20,7 @@
     <Content Include="README" />
     <Compile Include="pydocumentdb\errors.py" />
     <Compile Include="pydocumentdb\http_constants.py" />
-    <Compile Include="pydocumentdb\query_iterator.py" />
+    <Compile Include="pydocumentdb\query_iterable.py" />
     <Compile Include="pydocumentdb\runtime_constants.py" />
     <Compile Include="setup.py" />
     <Compile Include="test\crud_tests.py" />


### PR DESCRIPTION
1) Adds support for a new header option "enableScanInQuery"
2) Removes JPath query
3) Fixes python.pyproj file
4) Uses attachment id instead of media id in the UpdateMedia method.
