### PR TITLE
Connection pool parameter is missing in connection policy

### DIFF
--- a/pydocumentdb/documents.py
+++ b/pydocumentdb/documents.py
@@ -23,6 +23,8 @@
 """
 
 import pydocumentdb.retry_options as retry_options
+from pydocumentdb.http_constants import HttpConnectionProperties
+
 
 class DatabaseAccount(object):
     """Database account. A DatabaseAccount is the container for databases.

--- a/pydocumentdb/documents.py
+++ b/pydocumentdb/documents.py
@@ -284,6 +284,9 @@ class ProxyConfiguration(object):
         self.Port = None
 
 
+
+
+
 class ConnectionPolicy(object):
     """Represents the Connection policy assocated with a DocumentClient.
 
@@ -328,7 +331,8 @@ class ConnectionPolicy(object):
         self.EnableEndpointDiscovery = True
         self.PreferredLocations = []
         self.RetryOptions = retry_options.RetryOptions()
-        self.DisableSSLVerification = False;
+        self.DisableSSLVerification = False
+        self.HTTPRequestPoolSize = HttpConnectionProperties.MaxPoolSize
 
 class Undefined(object):
     """Represents undefined value for partitionKey when it's mising.

--- a/pydocumentdb/http_constants.py
+++ b/pydocumentdb/http_constants.py
@@ -266,3 +266,13 @@ class HttpContextProperties:
     """Constants of http context properties.
     """
     SubscriptionId = 'SubscriptionId'
+
+
+class HttpConnectionProperties:
+    """Constants of http connection properties.
+    """
+
+    # Max pool size increased from 10 to 25 as it is not typical http request,
+    # this is a database connection which requires more number of connections
+    # for parallel writes, queries, reads etc
+    MaxPoolSize = 25


### PR DESCRIPTION
Connection pool parameter added in default connection policy.
Default connection pool size is 10 which is set by requests lib. I have updated it to 25 as it is not typical https connection.
For parallel writes and reads connection pool size is little low and there is no way to increase it from lib. That's why I have added default parameter in connection policy and it can also be customized externally.
