### PR TITLE
Non partitioned container support for V3 SDK

### DIFF
--- a/azure/cosmos/base.py
+++ b/azure/cosmos/base.py
@@ -143,17 +143,15 @@ def GetHeaders(cosmos_client_connection,
         headers[http_constants.HttpHeaders.OfferThroughput] = options['offerThroughput']
 
     if 'partitionKey' in options:
-        # if partitionKey value is Undefined and systemKey is False in partition key definition,
+        # if partitionKey value is Undefined or Empty, and systemKey is False in partition key definition,
         # serialize it as {} to be consistent with other SDKs. If systemKey is True, serialize it
-        # as [] which corresponds to Empty partition key
-        if options.get('partitionKey') is documents.Undefined:
+        # as [], which is the equivalent to be sent for migrated collections
+        if (options.get('partitionKey') is documents._Undefined or
+                options.get('partitionKey') is partition_key.Empty):
             if is_system_key:
                 headers[http_constants.HttpHeaders.PartitionKey] = []
             else:
                 headers[http_constants.HttpHeaders.PartitionKey] = [{}]
-        # else if partitionKey value is Empty, serialize it as []
-        elif options.get('partitionKey') is partition_key.Empty:
-            headers[http_constants.HttpHeaders.PartitionKey] = []
         # else serialize using json dumps method which apart from regular values will serialize None into null
         else:
             headers[http_constants.HttpHeaders.PartitionKey] = json.dumps([options['partitionKey']])

--- a/azure/cosmos/base.py
+++ b/azure/cosmos/base.py
@@ -145,7 +145,7 @@ def GetHeaders(cosmos_client_connection,
         # if partitionKey value is Undefined, serialize it as [{}] to be consistent with other SDKs.
         if options.get('partitionKey') is partition_key._Undefined:
             headers[http_constants.HttpHeaders.PartitionKey] = [{}]
-        # If partitionKey value is None, serialize it as [], which is the equivalent to be sent for migrated collections
+        # If partitionKey value is Empty, serialize it as [], which is the equivalent to be sent for migrated collections
         elif options.get('partitionKey') is partition_key._Empty:
             headers[http_constants.HttpHeaders.PartitionKey] = []
         # else serialize using json dumps method which apart from regular values will serialize None into null

--- a/azure/cosmos/base.py
+++ b/azure/cosmos/base.py
@@ -143,10 +143,10 @@ def GetHeaders(cosmos_client_connection,
 
     if 'partitionKey' in options:
         # if partitionKey value is Undefined, serialize it as [{}] to be consistent with other SDKs.
-        if options.get('partitionKey') is partition_key.Undefined:
+        if options.get('partitionKey') is partition_key._Undefined:
             headers[http_constants.HttpHeaders.PartitionKey] = [{}]
         # If partitionKey value is None, serialize it as [], which is the equivalent to be sent for migrated collections
-        elif options.get('partitionKey') is partition_key.NonePk:
+        elif options.get('partitionKey') is partition_key._Empty:
             headers[http_constants.HttpHeaders.PartitionKey] = []
         # else serialize using json dumps method which apart from regular values will serialize None into null
         else:

--- a/azure/cosmos/base.py
+++ b/azure/cosmos/base.py
@@ -47,8 +47,7 @@ def GetHeaders(cosmos_client_connection,
                resource_id,
                resource_type,
                options,
-               partition_key_range_id = None,
-               is_system_key=False):
+               partition_key_range_id = None):
     """Gets HTTP request headers.
 
     :param cosmos_client_connection.CosmosClient cosmos_client:
@@ -143,15 +142,12 @@ def GetHeaders(cosmos_client_connection,
         headers[http_constants.HttpHeaders.OfferThroughput] = options['offerThroughput']
 
     if 'partitionKey' in options:
-        # if partitionKey value is Undefined or Empty, and systemKey is False in partition key definition,
-        # serialize it as {} to be consistent with other SDKs. If systemKey is True, serialize it
-        # as [], which is the equivalent to be sent for migrated collections
-        if (options.get('partitionKey') is documents._Undefined or
-                options.get('partitionKey') is partition_key.Empty):
-            if is_system_key:
-                headers[http_constants.HttpHeaders.PartitionKey] = []
-            else:
-                headers[http_constants.HttpHeaders.PartitionKey] = [{}]
+        # if partitionKey value is Undefined, serialize it as [{}] to be consistent with other SDKs.
+        if options.get('partitionKey') is partition_key.Undefined:
+            headers[http_constants.HttpHeaders.PartitionKey] = [{}]
+        # If partitionKey value is None, serialize it as [], which is the equivalent to be sent for migrated collections
+        elif options.get('partitionKey') is partition_key.NonePk:
+            headers[http_constants.HttpHeaders.PartitionKey] = []
         # else serialize using json dumps method which apart from regular values will serialize None into null
         else:
             headers[http_constants.HttpHeaders.PartitionKey] = json.dumps([options['partitionKey']])

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -61,6 +61,8 @@ class Container:
         database_link = CosmosClientConnection._get_database_link(database)
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
         self.scripts = Scripts(self.client_connection, self.container_link)
+        self.client_connection.is_system_key = (self.properties['partitionKey']['systemKey']
+                                                if 'systemKey' in self.properties['partitionKey'] else False)
 
     def _get_document_link(self, item_or_link):
         # type: (Union[Dict[str, Any], str, Item]) -> str

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -105,8 +105,7 @@ class Container:
 
         request_options = {}  # type: Dict[str, Any]
         if partition_key:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
         if session_token:
             request_options["sessionToken"] = session_token
         if initial_headers:
@@ -240,8 +239,7 @@ class Container:
         if populate_query_metrics is not None:
             request_options["populateQueryMetrics"] = populate_query_metrics
         if partition_key is not None:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
         if enable_scan_in_query is not None:
             request_options["enableScanInQuery"] = enable_scan_in_query
 
@@ -401,8 +399,7 @@ class Container:
         """
         request_options = {}  # type: Dict[str, Any]
         if partition_key:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
         if session_token:
             request_options["sessionToken"] = session_token
         if initial_headers:
@@ -503,8 +500,7 @@ class Container:
         if enable_cross_partition_query is not None:
             request_options["enableCrossPartitionQuery"] = enable_cross_partition_query
         if partition_key is not None:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
 
         return self.client_connection.QueryConflicts(
             collection_link=self.container_link,
@@ -530,8 +526,7 @@ class Container:
         """
         request_options = {}  # type: Dict[str, Any]
         if partition_key:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
 
         return self.client_connection.ReadConflict(
             conflict_link=self._get_conflict_link(id),
@@ -549,11 +544,15 @@ class Container:
         """
         request_options = {}  # type: Dict[str, Any]
         if partition_key:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
-                                               if partition_key == NonePartitionKeyValue else partition_key)
+            request_options["partitionKey"] = self._set_partition_key(partition_key)
 
         self.client_connection.DeleteConflict(
             conflict_link=self._get_conflict_link(id),
             options=request_options
         )
 
+    def _set_partition_key(self, partition_key):
+        if partition_key == NonePartitionKeyValue:
+            return CosmosClientConnection._ReturnUndefinedOrEmptyPartitionKey(self.is_system_key)
+        else:
+         return partition_key

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -60,9 +60,9 @@ class Container:
         self.properties = properties
         database_link = CosmosClientConnection._get_database_link(database)
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
-        self.scripts = Scripts(self.client_connection, self.container_link)
         self.is_system_key = (self.properties['partitionKey']['systemKey']
                               if 'systemKey' in self.properties['partitionKey'] else False)
+        self.scripts = Scripts(self.client_connection, self.container_link, self.is_system_key)
 
     def _get_document_link(self, item_or_link):
         # type: (Union[Dict[str, Any], str, Item]) -> str
@@ -114,7 +114,7 @@ class Container:
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         result = self.client_connection.ReadItem(
-            document_link=doc_link, options=request_options
+            document_link=doc_link, options=request_options, is_system_key=self.is_system_key
         )
         return Item(data=result)
 
@@ -147,7 +147,7 @@ class Container:
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         items = self.client_connection.ReadItems(
-            collection_link=self.container_link, feed_options=request_options
+            collection_link=self.container_link, feed_options=request_options, is_system_key=self.is_system_key
         )
         return items
 
@@ -250,6 +250,7 @@ class Container:
             else dict(query=query, parameters=parameters),
             options=request_options,
             partition_key=partition_key,
+            is_system_key=self.is_system_key
         )
         return items
 
@@ -414,7 +415,7 @@ class Container:
 
         document_link = self._get_document_link(item)
         self.client_connection.DeleteItem(
-            document_link=document_link, options=request_options or None
+            document_link=document_link, options=request_options, is_system_key=self.is_system_key
         )
 
     def read_offer(self):

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -553,6 +553,6 @@ class Container:
 
     def _set_partition_key(self, partition_key):
         if partition_key == NonePartitionKeyValue:
-            return CosmosClientConnection._ReturnUndefinedOrEmptyPartitionKey(self.is_system_key)
+            return CosmosClientConnection._return_undefined_or_empty_partition_key(self.is_system_key)
         else:
          return partition_key

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -60,9 +60,7 @@ class Container:
         self.properties = properties
         database_link = CosmosClientConnection._get_database_link(database)
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
-        self.is_system_key = (self.properties['partitionKey']['systemKey']
-                              if 'systemKey' in self.properties['partitionKey'] else False)
-        self.scripts = Scripts(self.client_connection, self.container_link, self.is_system_key)
+        self.scripts = Scripts(self.client_connection, self.container_link)
 
     def _get_document_link(self, item_or_link):
         # type: (Union[Dict[str, Any], str, Item]) -> str
@@ -114,7 +112,7 @@ class Container:
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         result = self.client_connection.ReadItem(
-            document_link=doc_link, options=request_options, is_system_key=self.is_system_key
+            document_link=doc_link, options=request_options
         )
         return Item(data=result)
 
@@ -147,7 +145,7 @@ class Container:
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         items = self.client_connection.ReadItems(
-            collection_link=self.container_link, feed_options=request_options, is_system_key=self.is_system_key
+            collection_link=self.container_link, feed_options=request_options
         )
         return items
 
@@ -249,8 +247,7 @@ class Container:
             if parameters is None
             else dict(query=query, parameters=parameters),
             options=request_options,
-            partition_key=partition_key,
-            is_system_key=self.is_system_key
+            partition_key=partition_key
         )
         return items
 
@@ -286,8 +283,7 @@ class Container:
         data = self.client_connection.ReplaceItem(
             document_link=item_link,
             new_document=body,
-            options=request_options,
-            is_system_key=self.is_system_key
+            options=request_options
         )
         return Item(data=data)
 
@@ -323,8 +319,7 @@ class Container:
 
         result = self.client_connection.UpsertItem(
             database_or_Container_link=self.container_link,
-            document=body,
-            is_system_key=self.is_system_key
+            document=body
         )
         return Item(data=result)
 
@@ -376,8 +371,7 @@ class Container:
         result = self.client_connection.CreateItem(
             database_or_Container_link=self.container_link,
             document=body,
-            options=request_options,
-            is_system_key=self.is_system_key
+            options=request_options
         )
         return Item(data=result)
 
@@ -415,7 +409,7 @@ class Container:
 
         document_link = self._get_document_link(item)
         self.client_connection.DeleteItem(
-            document_link=document_link, options=request_options, is_system_key=self.is_system_key
+            document_link=document_link, options=request_options
         )
 
     def read_offer(self):

--- a/azure/cosmos/container.py
+++ b/azure/cosmos/container.py
@@ -61,8 +61,8 @@ class Container:
         database_link = CosmosClientConnection._get_database_link(database)
         self.container_link = u"{}/colls/{}".format(database_link, self.id)
         self.scripts = Scripts(self.client_connection, self.container_link)
-        self.client_connection.is_system_key = (self.properties['partitionKey']['systemKey']
-                                                if 'systemKey' in self.properties['partitionKey'] else False)
+        self.is_system_key = (self.properties['partitionKey']['systemKey']
+                              if 'systemKey' in self.properties['partitionKey'] else False)
 
     def _get_document_link(self, item_or_link):
         # type: (Union[Dict[str, Any], str, Item]) -> str
@@ -283,7 +283,10 @@ class Container:
         if populate_query_metrics is not None:
             request_options["populateQueryMetrics"] = populate_query_metrics
         data = self.client_connection.ReplaceItem(
-            document_link=item_link, new_document=body, options=request_options
+            document_link=item_link,
+            new_document=body,
+            options=request_options,
+            is_system_key=self.is_system_key
         )
         return Item(data=data)
 
@@ -318,7 +321,9 @@ class Container:
             request_options["populateQueryMetrics"] = populate_query_metrics
 
         result = self.client_connection.UpsertItem(
-            database_or_Container_link=self.container_link, document=body
+            database_or_Container_link=self.container_link,
+            document=body,
+            is_system_key=self.is_system_key
         )
         return Item(data=result)
 
@@ -371,6 +376,7 @@ class Container:
             database_or_Container_link=self.container_link,
             document=body,
             options=request_options,
+            is_system_key=self.is_system_key
         )
         return Item(data=result)
 

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -2899,7 +2899,7 @@ class CosmosClientConnection(object):
         for part in partition_key_parts:
             # At any point if we don't find the value of a sub-property in the document, we return as Undefined
             if part not in partitionKey:
-                return self._ReturnUndefinedOrNonePartitionKey(is_system_key)
+                return self._ReturnUndefinedOrEmptyPartitionKey(is_system_key)
             else:
                 partitionKey = partitionKey.get(part)
                 matchCount += 1
@@ -2909,7 +2909,7 @@ class CosmosClientConnection(object):
 
         # Match the count of hops we did to get the partitionKey with the length of partition key parts and validate that it's not a dict at that level
         if ((matchCount != expected_matchCount) or isinstance(partitionKey, dict)):
-            return self._ReturnUndefinedOrNonePartitionKey(is_system_key)
+            return self._ReturnUndefinedOrEmptyPartitionKey(is_system_key)
 
         return partitionKey
 
@@ -2958,7 +2958,7 @@ class CosmosClientConnection(object):
         return "dbs/{}".format(database_id)
 
     @staticmethod
-    def _ReturnUndefinedOrNonePartitionKey(is_system_key):
+    def _ReturnUndefinedOrEmptyPartitionKey(is_system_key):
         if is_system_key:
             return _Empty
         else:

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -152,6 +152,7 @@ class CosmosClientConnection(object):
 
         database_account = self._global_endpoint_manager._GetDatabaseAccount()
         self._global_endpoint_manager.force_refresh(database_account)
+        self.is_system_key = False
 
     @property
     def Session(self):
@@ -2436,7 +2437,8 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options)
+                                  options,
+                                  is_system_key=self.is_system_key)
         # Create will use WriteEndpoint since it uses POST operation
 
         request = request_object._RequestObject(type, documents._OperationType.Create)
@@ -2476,7 +2478,8 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options)
+                                  options,
+                                  is_system_key=self.is_system_key)
 
         headers[http_constants.HttpHeaders.IsUpsert] = True
 
@@ -2517,7 +2520,8 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options)
+                                  options,
+                                  is_system_key=self.is_system_key)
         # Replace will use WriteEndpoint since it uses PUT operation
         request = request_object._RequestObject(type, documents._OperationType.Replace)
         result, self.last_response_headers = self.__Put(path,
@@ -2908,7 +2912,7 @@ class CosmosClientConnection(object):
             return documents.Undefined
          
         return partitionKey
-    
+
     def _UpdateSessionIfRequired(self, request_headers, response_result, response_headers):    
         """
         Updates session if necessary.

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -152,7 +152,6 @@ class CosmosClientConnection(object):
 
         database_account = self._global_endpoint_manager._GetDatabaseAccount()
         self._global_endpoint_manager.force_refresh(database_account)
-        self.is_system_key = False
 
     @property
     def Session(self):
@@ -985,7 +984,7 @@ class CosmosClientConnection(object):
                                     options), self.last_response_headers
         return query_iterable.QueryIterable(self, query, options, fetch_fn)
 
-    def CreateItem(self, database_or_Container_link, document, options=None):
+    def CreateItem(self, database_or_Container_link, document, options=None, is_system_key=False):
         """Creates a document in a collection.
 
         :param str database_or_Container_link:
@@ -1021,9 +1020,10 @@ class CosmosClientConnection(object):
                            'docs',
                            collection_id,
                            None,
-                           options)
+                           options,
+                           is_system_key)
 
-    def UpsertItem(self, database_or_Container_link, document, options=None):
+    def UpsertItem(self, database_or_Container_link, document, options=None, is_system_key=False):
         """Upserts a document in a collection.
 
         :param str database_or_Container_link:
@@ -1059,7 +1059,8 @@ class CosmosClientConnection(object):
                            'docs',
                            collection_id,
                            None,
-                           options)
+                           options,
+                           is_system_key)
 
     PartitionResolverErrorMessage = "Couldn't find any partition resolvers for the database link provided. Ensure that the link you used when registering the partition resolvers matches the link provided or you need to register both types of database link(self link as well as ID based link)."
 
@@ -1618,7 +1619,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ReplaceItem(self, document_link, new_document, options=None):
+    def ReplaceItem(self, document_link, new_document, options=None, is_system_key=False):
         """Replaces a document and returns it.
 
         :param str document_link:
@@ -1653,7 +1654,8 @@ class CosmosClientConnection(object):
                             'docs',
                             document_id,
                             None,
-                            options)
+                            options,
+                            is_system_key)
 
     def DeleteItem(self, document_link, options=None):
         """Deletes a document.
@@ -2410,7 +2412,7 @@ class CosmosClientConnection(object):
         self._useMultipleWriteLocations = self.connection_policy.UseMultipleWriteLocations and database_account._EnableMultipleWritableLocations
         return database_account
 
-    def Create(self, body, path, type, id, initial_headers, options=None):
+    def Create(self, body, path, type, id, initial_headers, options=None, is_system_key=False):
         """Creates a Azure Cosmos resource and returns it.
 
         :param dict body:
@@ -2438,7 +2440,7 @@ class CosmosClientConnection(object):
                                   id,
                                   type,
                                   options,
-                                  is_system_key=self.is_system_key)
+                                  is_system_key=is_system_key)
         # Create will use WriteEndpoint since it uses POST operation
 
         request = request_object._RequestObject(type, documents._OperationType.Create)
@@ -2451,7 +2453,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Upsert(self, body, path, type, id, initial_headers, options=None):
+    def Upsert(self, body, path, type, id, initial_headers, options=None, is_system_key=False):
         """Upserts a Azure Cosmos resource and returns it.
         
         :param dict body:
@@ -2479,7 +2481,7 @@ class CosmosClientConnection(object):
                                   id,
                                   type,
                                   options,
-                                  is_system_key=self.is_system_key)
+                                  is_system_key=is_system_key)
 
         headers[http_constants.HttpHeaders.IsUpsert] = True
 
@@ -2493,7 +2495,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Replace(self, resource, path, type, id, initial_headers, options=None):
+    def Replace(self, resource, path, type, id, initial_headers, options=None, is_system_key=False):
         """Replaces a Azure Cosmos resource and returns it.
 
         :param dict resource:
@@ -2521,7 +2523,7 @@ class CosmosClientConnection(object):
                                   id,
                                   type,
                                   options,
-                                  is_system_key=self.is_system_key)
+                                  is_system_key=is_system_key)
         # Replace will use WriteEndpoint since it uses PUT operation
         request = request_object._RequestObject(type, documents._OperationType.Replace)
         result, self.last_response_headers = self.__Put(path,

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -816,7 +816,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ReadItems(self, collection_link, feed_options=None):
+    def ReadItems(self, collection_link, feed_options=None, is_system_key=False):
         """Reads all documents in a collection.
 
         :param str collection_link:
@@ -832,9 +832,9 @@ class CosmosClientConnection(object):
         if feed_options is None:
             feed_options = {}
 
-        return self.QueryItems(collection_link, None, feed_options)
+        return self.QueryItems(collection_link, None, feed_options, is_system_key)
 
-    def QueryItems(self, database_or_Container_link, query, options=None, partition_key=None):
+    def QueryItems(self, database_or_Container_link, query, options=None, partition_key=None, is_system_key=False):
         """Queries documents in a collection.
 
         :param str database_or_Container_link:
@@ -869,7 +869,8 @@ class CosmosClientConnection(object):
                                         lambda r: r['Documents'],
                                         lambda _, b: b,
                                         query,
-                                        options), self.last_response_headers
+                                        options,
+                                        is_system_key=is_system_key), self.last_response_headers
             return query_iterable.QueryIterable(self, query, options, fetch_fn, database_or_Container_link)
 
     def QueryItemsChangeFeed(self, collection_link, options=None):
@@ -1093,7 +1094,7 @@ class CosmosClientConnection(object):
         collection_id = base.GetResourceIdOrFullNameFromLink(collection_link)
         return collection_id, document, path
     
-    def ReadItem(self, document_link, options=None):
+    def ReadItem(self, document_link, options=None, is_system_key=False):
         """Reads a document.
 
         :param str document_link:
@@ -1116,7 +1117,8 @@ class CosmosClientConnection(object):
                          'docs',
                          document_id,
                          None,
-                         options)
+                         options,
+                         is_system_key)
 
     def ReadTriggers(self, collection_link, options=None):
         """Reads all triggers in a collection.
@@ -1657,7 +1659,7 @@ class CosmosClientConnection(object):
                             options,
                             is_system_key)
 
-    def DeleteItem(self, document_link, options=None):
+    def DeleteItem(self, document_link, options=None, is_system_key=False):
         """Deletes a document.
 
         :param str document_link:
@@ -1680,7 +1682,8 @@ class CosmosClientConnection(object):
                                    'docs',
                                    document_id,
                                    None,
-                                   options)
+                                   options,
+                                   is_system_key)
 
     def CreateAttachment(self, document_link, attachment, options=None):
         """Creates an attachment in a document.
@@ -2154,7 +2157,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ExecuteStoredProcedure(self, sproc_link, params, options=None):
+    def ExecuteStoredProcedure(self, sproc_link, params, options=None, is_system_key=False):
         """Executes a store procedure.
 
         :param str sproc_link:
@@ -2190,7 +2193,8 @@ class CosmosClientConnection(object):
                                   path,
                                   sproc_id,
                                   'sprocs',
-                                  options)
+                                  options,
+                                  is_system_key=is_system_key)
 
         # ExecuteStoredProcedure will use WriteEndpoint since it uses POST operation
         request = request_object._RequestObject('sprocs', documents._OperationType.ExecuteJavaScript)
@@ -2535,7 +2539,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Read(self, path, type, id, initial_headers, options=None):
+    def Read(self, path, type, id, initial_headers, options=None, is_system_key=False):
         """Reads a Azure Cosmos resource and returns it.
 
         :param str path:
@@ -2561,7 +2565,8 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options)
+                                  options,
+                                  is_system_key=is_system_key)
         # Read will use ReadEndpoint since it uses GET operation
         request = request_object._RequestObject(type, documents._OperationType.Read)
         result, self.last_response_headers = self.__Get(path,
@@ -2569,7 +2574,7 @@ class CosmosClientConnection(object):
                                                         headers)
         return result
 
-    def DeleteResource(self, path, type, id, initial_headers, options=None):
+    def DeleteResource(self, path, type, id, initial_headers, options=None, is_system_key=False):
         """Deletes a Azure Cosmos resource and returns it.
 
         :param str path:
@@ -2595,7 +2600,8 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options)
+                                  options,
+                                  is_system_key=is_system_key)
         # Delete will use WriteEndpoint since it uses DELETE operation
         request = request_object._RequestObject(type, documents._OperationType.Delete)
         result, self.last_response_headers = self.__Delete(path,
@@ -2739,7 +2745,8 @@ class CosmosClientConnection(object):
                     create_fn,
                     query,
                     options=None,
-                    partition_key_range_id=None):
+                    partition_key_range_id=None,
+                    is_system_key=False):
         """Query for more than one Azure Cosmos resources.
 
         :param str path:
@@ -2786,7 +2793,8 @@ class CosmosClientConnection(object):
                                       id,
                                       type,
                                       options,
-                                      partition_key_range_id)
+                                      partition_key_range_id,
+                                      is_system_key=is_system_key)
             result, self.last_response_headers = self.__Get(path,
                                                             request,
                                                             headers)
@@ -2812,7 +2820,8 @@ class CosmosClientConnection(object):
                                       id,
                                       type,
                                       options,
-                                      partition_key_range_id)
+                                      partition_key_range_id,
+                                      is_system_key=is_system_key)
             result, self.last_response_headers = self.__Post(path,
                                                              request,
                                                              query,
@@ -2901,7 +2910,7 @@ class CosmosClientConnection(object):
         for part in partition_key_parts:
             # At any point if we don't find the value of a sub-property in the document, we return as Undefined
             if part not in partitionKey:
-                return documents.Undefined
+                return documents._Undefined
             else:
                 partitionKey = partitionKey.get(part)
                 matchCount += 1
@@ -2911,7 +2920,7 @@ class CosmosClientConnection(object):
 
         # Match the count of hops we did to get the partitionKey with the length of partition key parts and validate that it's not a dict at that level
         if ((matchCount != expected_matchCount) or isinstance(partitionKey, dict)):
-            return documents.Undefined
+            return documents._Undefined
          
         return partitionKey
 

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -2888,10 +2888,10 @@ class CosmosClientConnection(object):
                          if 'systemKey' in partitionKeyDefinition else False)
 
         # Navigates the document to retrieve the partitionKey specified in the paths
-        return self._RetrievePartitionKey(partition_key_parts, document, is_system_key)
+        return self._retrieve_partition_key(partition_key_parts, document, is_system_key)
 
     # Navigates the document to retrieve the partitionKey specified in the partition key parts
-    def _RetrievePartitionKey(self, partition_key_parts, document, is_system_key):
+    def _retrieve_partition_key(self, partition_key_parts, document, is_system_key):
         expected_matchCount = len(partition_key_parts)
         matchCount = 0
         partitionKey = document
@@ -2899,7 +2899,7 @@ class CosmosClientConnection(object):
         for part in partition_key_parts:
             # At any point if we don't find the value of a sub-property in the document, we return as Undefined
             if part not in partitionKey:
-                return self._ReturnUndefinedOrEmptyPartitionKey(is_system_key)
+                return self._return_undefined_or_empty_partition_key(is_system_key)
             else:
                 partitionKey = partitionKey.get(part)
                 matchCount += 1
@@ -2909,7 +2909,7 @@ class CosmosClientConnection(object):
 
         # Match the count of hops we did to get the partitionKey with the length of partition key parts and validate that it's not a dict at that level
         if ((matchCount != expected_matchCount) or isinstance(partitionKey, dict)):
-            return self._ReturnUndefinedOrEmptyPartitionKey(is_system_key)
+            return self._return_undefined_or_empty_partition_key(is_system_key)
 
         return partitionKey
 
@@ -2958,7 +2958,7 @@ class CosmosClientConnection(object):
         return "dbs/{}".format(database_id)
 
     @staticmethod
-    def _ReturnUndefinedOrEmptyPartitionKey(is_system_key):
+    def _return_undefined_or_empty_partition_key(is_system_key):
         if is_system_key:
             return _Empty
         else:

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -37,7 +37,7 @@ from . import global_endpoint_manager
 from .routing import routing_map_provider as routing_map_provider
 from . import session
 from . import utils
-import partition_key
+from .partition_key import _Undefined, _Empty
 
 class CosmosClientConnection(object):
     """Represents a document client.
@@ -2913,12 +2913,6 @@ class CosmosClientConnection(object):
 
         return partitionKey
 
-    def _ReturnUndefinedOrNonePartitionKey(self, is_system_key):
-        if is_system_key:
-            return partition_key.NonePk
-        else:
-            return partition_key.Undefined
-
     def _UpdateSessionIfRequired(self, request_headers, response_result, response_headers):    
         """
         Updates session if necessary.
@@ -2962,3 +2956,11 @@ class CosmosClientConnection(object):
         else:
             database_id = cast("Dict[str, str]", database_or_id)["id"]
         return "dbs/{}".format(database_id)
+
+    @staticmethod
+    def _ReturnUndefinedOrNonePartitionKey(is_system_key):
+        if is_system_key:
+            return _Empty
+        else:
+            return _Undefined
+

--- a/azure/cosmos/cosmos_client_connection.py
+++ b/azure/cosmos/cosmos_client_connection.py
@@ -37,6 +37,7 @@ from . import global_endpoint_manager
 from .routing import routing_map_provider as routing_map_provider
 from . import session
 from . import utils
+import partition_key
 
 class CosmosClientConnection(object):
     """Represents a document client.
@@ -816,7 +817,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ReadItems(self, collection_link, feed_options=None, is_system_key=False):
+    def ReadItems(self, collection_link, feed_options=None):
         """Reads all documents in a collection.
 
         :param str collection_link:
@@ -832,9 +833,9 @@ class CosmosClientConnection(object):
         if feed_options is None:
             feed_options = {}
 
-        return self.QueryItems(collection_link, None, feed_options, is_system_key)
+        return self.QueryItems(collection_link, None, feed_options)
 
-    def QueryItems(self, database_or_Container_link, query, options=None, partition_key=None, is_system_key=False):
+    def QueryItems(self, database_or_Container_link, query, options=None, partition_key=None):
         """Queries documents in a collection.
 
         :param str database_or_Container_link:
@@ -869,8 +870,7 @@ class CosmosClientConnection(object):
                                         lambda r: r['Documents'],
                                         lambda _, b: b,
                                         query,
-                                        options,
-                                        is_system_key=is_system_key), self.last_response_headers
+                                        options), self.last_response_headers
             return query_iterable.QueryIterable(self, query, options, fetch_fn, database_or_Container_link)
 
     def QueryItemsChangeFeed(self, collection_link, options=None):
@@ -985,7 +985,7 @@ class CosmosClientConnection(object):
                                     options), self.last_response_headers
         return query_iterable.QueryIterable(self, query, options, fetch_fn)
 
-    def CreateItem(self, database_or_Container_link, document, options=None, is_system_key=False):
+    def CreateItem(self, database_or_Container_link, document, options=None):
         """Creates a document in a collection.
 
         :param str database_or_Container_link:
@@ -1021,10 +1021,9 @@ class CosmosClientConnection(object):
                            'docs',
                            collection_id,
                            None,
-                           options,
-                           is_system_key)
+                           options)
 
-    def UpsertItem(self, database_or_Container_link, document, options=None, is_system_key=False):
+    def UpsertItem(self, database_or_Container_link, document, options=None):
         """Upserts a document in a collection.
 
         :param str database_or_Container_link:
@@ -1060,8 +1059,7 @@ class CosmosClientConnection(object):
                            'docs',
                            collection_id,
                            None,
-                           options,
-                           is_system_key)
+                           options)
 
     PartitionResolverErrorMessage = "Couldn't find any partition resolvers for the database link provided. Ensure that the link you used when registering the partition resolvers matches the link provided or you need to register both types of database link(self link as well as ID based link)."
 
@@ -1094,7 +1092,7 @@ class CosmosClientConnection(object):
         collection_id = base.GetResourceIdOrFullNameFromLink(collection_link)
         return collection_id, document, path
     
-    def ReadItem(self, document_link, options=None, is_system_key=False):
+    def ReadItem(self, document_link, options=None):
         """Reads a document.
 
         :param str document_link:
@@ -1117,8 +1115,7 @@ class CosmosClientConnection(object):
                          'docs',
                          document_id,
                          None,
-                         options,
-                         is_system_key)
+                         options)
 
     def ReadTriggers(self, collection_link, options=None):
         """Reads all triggers in a collection.
@@ -1621,7 +1618,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ReplaceItem(self, document_link, new_document, options=None, is_system_key=False):
+    def ReplaceItem(self, document_link, new_document, options=None):
         """Replaces a document and returns it.
 
         :param str document_link:
@@ -1656,10 +1653,9 @@ class CosmosClientConnection(object):
                             'docs',
                             document_id,
                             None,
-                            options,
-                            is_system_key)
+                            options)
 
-    def DeleteItem(self, document_link, options=None, is_system_key=False):
+    def DeleteItem(self, document_link, options=None):
         """Deletes a document.
 
         :param str document_link:
@@ -1682,8 +1678,7 @@ class CosmosClientConnection(object):
                                    'docs',
                                    document_id,
                                    None,
-                                   options,
-                                   is_system_key)
+                                   options)
 
     def CreateAttachment(self, document_link, attachment, options=None):
         """Creates an attachment in a document.
@@ -2157,7 +2152,7 @@ class CosmosClientConnection(object):
                                    None,
                                    options)
 
-    def ExecuteStoredProcedure(self, sproc_link, params, options=None, is_system_key=False):
+    def ExecuteStoredProcedure(self, sproc_link, params, options=None):
         """Executes a store procedure.
 
         :param str sproc_link:
@@ -2193,8 +2188,7 @@ class CosmosClientConnection(object):
                                   path,
                                   sproc_id,
                                   'sprocs',
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
 
         # ExecuteStoredProcedure will use WriteEndpoint since it uses POST operation
         request = request_object._RequestObject('sprocs', documents._OperationType.ExecuteJavaScript)
@@ -2416,7 +2410,7 @@ class CosmosClientConnection(object):
         self._useMultipleWriteLocations = self.connection_policy.UseMultipleWriteLocations and database_account._EnableMultipleWritableLocations
         return database_account
 
-    def Create(self, body, path, type, id, initial_headers, options=None, is_system_key=False):
+    def Create(self, body, path, type, id, initial_headers, options=None):
         """Creates a Azure Cosmos resource and returns it.
 
         :param dict body:
@@ -2443,8 +2437,7 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
         # Create will use WriteEndpoint since it uses POST operation
 
         request = request_object._RequestObject(type, documents._OperationType.Create)
@@ -2457,7 +2450,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Upsert(self, body, path, type, id, initial_headers, options=None, is_system_key=False):
+    def Upsert(self, body, path, type, id, initial_headers, options=None):
         """Upserts a Azure Cosmos resource and returns it.
         
         :param dict body:
@@ -2484,8 +2477,7 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
 
         headers[http_constants.HttpHeaders.IsUpsert] = True
 
@@ -2499,7 +2491,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Replace(self, resource, path, type, id, initial_headers, options=None, is_system_key=False):
+    def Replace(self, resource, path, type, id, initial_headers, options=None):
         """Replaces a Azure Cosmos resource and returns it.
 
         :param dict resource:
@@ -2526,8 +2518,7 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
         # Replace will use WriteEndpoint since it uses PUT operation
         request = request_object._RequestObject(type, documents._OperationType.Replace)
         result, self.last_response_headers = self.__Put(path,
@@ -2539,7 +2530,7 @@ class CosmosClientConnection(object):
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
         return result
 
-    def Read(self, path, type, id, initial_headers, options=None, is_system_key=False):
+    def Read(self, path, type, id, initial_headers, options=None):
         """Reads a Azure Cosmos resource and returns it.
 
         :param str path:
@@ -2565,8 +2556,7 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
         # Read will use ReadEndpoint since it uses GET operation
         request = request_object._RequestObject(type, documents._OperationType.Read)
         result, self.last_response_headers = self.__Get(path,
@@ -2574,7 +2564,7 @@ class CosmosClientConnection(object):
                                                         headers)
         return result
 
-    def DeleteResource(self, path, type, id, initial_headers, options=None, is_system_key=False):
+    def DeleteResource(self, path, type, id, initial_headers, options=None):
         """Deletes a Azure Cosmos resource and returns it.
 
         :param str path:
@@ -2600,8 +2590,7 @@ class CosmosClientConnection(object):
                                   path,
                                   id,
                                   type,
-                                  options,
-                                  is_system_key=is_system_key)
+                                  options)
         # Delete will use WriteEndpoint since it uses DELETE operation
         request = request_object._RequestObject(type, documents._OperationType.Delete)
         result, self.last_response_headers = self.__Delete(path,
@@ -2745,8 +2734,7 @@ class CosmosClientConnection(object):
                     create_fn,
                     query,
                     options=None,
-                    partition_key_range_id=None,
-                    is_system_key=False):
+                    partition_key_range_id=None):
         """Query for more than one Azure Cosmos resources.
 
         :param str path:
@@ -2793,8 +2781,7 @@ class CosmosClientConnection(object):
                                       id,
                                       type,
                                       options,
-                                      partition_key_range_id,
-                                      is_system_key=is_system_key)
+                                      partition_key_range_id)
             result, self.last_response_headers = self.__Get(path,
                                                             request,
                                                             headers)
@@ -2820,8 +2807,7 @@ class CosmosClientConnection(object):
                                       id,
                                       type,
                                       options,
-                                      partition_key_range_id,
-                                      is_system_key=is_system_key)
+                                      partition_key_range_id)
             result, self.last_response_headers = self.__Post(path,
                                                              request,
                                                              query,
@@ -2897,12 +2883,15 @@ class CosmosClientConnection(object):
 
         # Parses the paths into a list of token each representing a property
         partition_key_parts = base.ParsePaths(partitionKeyDefinition.get('paths'))
+        # Check if the partitionKey is system generated or not
+        is_system_key = (partitionKeyDefinition['systemKey']
+                         if 'systemKey' in partitionKeyDefinition else False)
 
         # Navigates the document to retrieve the partitionKey specified in the paths
-        return self._RetrievePartitionKey(partition_key_parts, document)
+        return self._RetrievePartitionKey(partition_key_parts, document, is_system_key)
 
     # Navigates the document to retrieve the partitionKey specified in the partition key parts
-    def _RetrievePartitionKey(self, partition_key_parts, document):
+    def _RetrievePartitionKey(self, partition_key_parts, document, is_system_key):
         expected_matchCount = len(partition_key_parts)
         matchCount = 0
         partitionKey = document
@@ -2910,7 +2899,7 @@ class CosmosClientConnection(object):
         for part in partition_key_parts:
             # At any point if we don't find the value of a sub-property in the document, we return as Undefined
             if part not in partitionKey:
-                return documents._Undefined
+                return self._ReturnUndefinedOrNonePartitionKey(is_system_key)
             else:
                 partitionKey = partitionKey.get(part)
                 matchCount += 1
@@ -2920,9 +2909,15 @@ class CosmosClientConnection(object):
 
         # Match the count of hops we did to get the partitionKey with the length of partition key parts and validate that it's not a dict at that level
         if ((matchCount != expected_matchCount) or isinstance(partitionKey, dict)):
-            return documents._Undefined
-         
+            return self._ReturnUndefinedOrNonePartitionKey(is_system_key)
+
         return partitionKey
+
+    def _ReturnUndefinedOrNonePartitionKey(self, is_system_key):
+        if is_system_key:
+            return partition_key.NonePk
+        else:
+            return partition_key.Undefined
 
     def _UpdateSessionIfRequired(self, request_headers, response_result, response_headers):    
         """
@@ -2947,7 +2942,7 @@ class CosmosClientConnection(object):
         if http_constants.HttpHeaders.ConsistencyLevel in request_headers:
             if documents.ConsistencyLevel.Session == request_headers[http_constants.HttpHeaders.ConsistencyLevel]:
                 is_session_consistency = True
-              
+
         if is_session_consistency:
             # update session
             self.session.update_session(response_result, response_headers)

--- a/azure/cosmos/documents.py
+++ b/azure/cosmos/documents.py
@@ -372,7 +372,7 @@ class ConnectionPolicy(object):
         self.DisableSSLVerification = False
         self.UseMultipleWriteLocations = False
 
-class Undefined(object):
+class _Undefined(object):
     """Represents undefined value for partitionKey when it's mising.
     """
 

--- a/azure/cosmos/documents.py
+++ b/azure/cosmos/documents.py
@@ -372,10 +372,6 @@ class ConnectionPolicy(object):
         self.DisableSSLVerification = False
         self.UseMultipleWriteLocations = False
 
-class _Undefined(object):
-    """Represents undefined value for partitionKey when it's mising.
-    """
-
 class _OperationType(object):
     """Represents the type of the operation
     """

--- a/azure/cosmos/http_constants.py
+++ b/azure/cosmos/http_constants.py
@@ -255,7 +255,7 @@ class CookieHeaders:
 class Versions:
     """Constants of versions.
     """
-    CurrentVersion = '2018-09-17'
+    CurrentVersion = '2018-12-31'
     SDKName = 'azure-cosmos'
     SDKVersion = '3.0.3-SNAPSHOT'
 

--- a/azure/cosmos/partition_key.py
+++ b/azure/cosmos/partition_key.py
@@ -19,6 +19,9 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
+class Empty(object):
+    """Represents empty value for partitionKey when it's missing.
+    """
 
 class PartitionKey(dict):
     """ Key used to partition a container into logical partitions.

--- a/azure/cosmos/partition_key.py
+++ b/azure/cosmos/partition_key.py
@@ -19,9 +19,16 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
-class Empty(object):
-    """Represents empty value for partitionKey when it's missing.
+
+class NonePk(object):
+    """Represents none value for partitionKey when it's missing in migrated containers.
     """
+
+
+class Undefined(object):
+    """Represents undefined value for partitionKey when it's missing.
+    """
+
 
 class PartitionKey(dict):
     """ Key used to partition a container into logical partitions.

--- a/azure/cosmos/partition_key.py
+++ b/azure/cosmos/partition_key.py
@@ -20,13 +20,18 @@
 #SOFTWARE.
 
 
-class NonePk(object):
-    """Represents none value for partitionKey when it's missing in migrated containers.
+class NonePartitionKeyValue(object):
+    """Represents none value for partitionKey when it's missing in a containers.
     """
 
 
-class Undefined(object):
-    """Represents undefined value for partitionKey when it's missing.
+class _Empty(object):
+    """Represents empty value for partitionKey when it's missing in an item belonging to a migrated container.
+    """
+
+
+class _Undefined(object):
+    """Represents undefined value for partitionKey when it's missing in an item belonging to a multi-partition container.
     """
 
 

--- a/azure/cosmos/scripts.py
+++ b/azure/cosmos/scripts.py
@@ -33,11 +33,10 @@ class ScriptType:
 
 class Scripts:
 
-    def __init__(self, client_connection, container_link, is_system_key):
+    def __init__(self, client_connection, container_link):
         # type: (CosmosClientConnection, Union[Container, str], str, Dict[str, Any]) -> None
         self.client_connection = client_connection
         self.container_link = container_link
-        self.is_system_key = is_system_key
 
     def _get_resource_link(self, id, type):
         return u"{}/{}/{}".format(self.container_link, type, id)
@@ -155,8 +154,7 @@ class Scripts:
         return self.client_connection.ExecuteStoredProcedure(
             sproc_link=self._get_resource_link(id, ScriptType.StoredProcedure),
             params=params,
-            options=request_options,
-            is_system_key=self.is_system_key
+            options=request_options
         )
 
     def list_triggers(self, max_item_count=None):

--- a/azure/cosmos/scripts.py
+++ b/azure/cosmos/scripts.py
@@ -23,6 +23,7 @@
 """
 
 from azure.cosmos.cosmos_client_connection import CosmosClientConnection
+from .partition_key import NonePartitionKeyValue
 
 
 class ScriptType:
@@ -33,10 +34,11 @@ class ScriptType:
 
 class Scripts:
 
-    def __init__(self, client_connection, container_link):
+    def __init__(self, client_connection, container_link, is_system_key):
         # type: (CosmosClientConnection, Union[Container, str], str, Dict[str, Any]) -> None
         self.client_connection = client_connection
         self.container_link = container_link
+        self.is_system_key = is_system_key
 
     def _get_resource_link(self, id, type):
         return u"{}/{}/{}".format(self.container_link, type, id)
@@ -147,7 +149,8 @@ class Scripts:
 
         request_options = {}  # type: Dict[str, Any]
         if partition_key is not None:
-            request_options["partitionKey"] = partition_key
+            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
+                                               if partition_key == NonePartitionKeyValue else partition_key)
         if enable_script_logging is not None:
             request_options["enableScriptLogging"] = enable_script_logging
 

--- a/azure/cosmos/scripts.py
+++ b/azure/cosmos/scripts.py
@@ -33,10 +33,11 @@ class ScriptType:
 
 class Scripts:
 
-    def __init__(self, client_connection, container_link):
+    def __init__(self, client_connection, container_link, is_system_key):
         # type: (CosmosClientConnection, Union[Container, str], str, Dict[str, Any]) -> None
         self.client_connection = client_connection
         self.container_link = container_link
+        self.is_system_key = is_system_key
 
     def _get_resource_link(self, id, type):
         return u"{}/{}/{}".format(self.container_link, type, id)
@@ -154,7 +155,8 @@ class Scripts:
         return self.client_connection.ExecuteStoredProcedure(
             sproc_link=self._get_resource_link(id, ScriptType.StoredProcedure),
             params=params,
-            options=request_options
+            options=request_options,
+            is_system_key=self.is_system_key
         )
 
     def list_triggers(self, max_item_count=None):

--- a/azure/cosmos/scripts.py
+++ b/azure/cosmos/scripts.py
@@ -149,7 +149,7 @@ class Scripts:
 
         request_options = {}  # type: Dict[str, Any]
         if partition_key is not None:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrEmptyPartitionKey(self.is_system_key)
+            request_options["partitionKey"] = (CosmosClientConnection._return_undefined_or_empty_partition_key(self.is_system_key)
                                                if partition_key == NonePartitionKeyValue else partition_key)
         if enable_script_logging is not None:
             request_options["enableScriptLogging"] = enable_script_logging

--- a/azure/cosmos/scripts.py
+++ b/azure/cosmos/scripts.py
@@ -149,7 +149,7 @@ class Scripts:
 
         request_options = {}  # type: Dict[str, Any]
         if partition_key is not None:
-            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrNonePartitionKey(self.is_system_key)
+            request_options["partitionKey"] = (CosmosClientConnection._ReturnUndefinedOrEmptyPartitionKey(self.is_system_key)
                                                if partition_key == NonePartitionKeyValue else partition_key)
         if enable_script_logging is not None:
             request_options["enableScriptLogging"] = enable_script_logging

--- a/samples/DocumentDB.Samples.sln
+++ b/samples/DocumentDB.Samples.sln
@@ -19,6 +19,8 @@ Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "IndexManagement", "IndexMan
 EndProject
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "MultiMasterOperations", "MultiMasterOperations\MultiMasterOperations.pyproj", "{F29D7A3E-CB9A-4B15-BDA1-BB30F3CA9CFA}"
 EndProject
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "NonPartitionedCollectionOperations", "NonPartitionedCollectionOperations\NonPartitionedCollectionOperations.pyproj", "{475992ED-0ADF-48DB-BE7C-3F94F3E33A71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,8 @@ Global
 		{B1869509-4DC8-4AA8-8F2A-220FDBC14154}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F29D7A3E-CB9A-4B15-BDA1-BB30F3CA9CFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F29D7A3E-CB9A-4B15-BDA1-BB30F3CA9CFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{475992ED-0ADF-48DB-BE7C-3F94F3E33A71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{475992ED-0ADF-48DB-BE7C-3F94F3E33A71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/NonPartitionedCollectionOperations/NonPartitionedCollectionOperations.pyproj
+++ b/samples/NonPartitionedCollectionOperations/NonPartitionedCollectionOperations.pyproj
@@ -1,0 +1,35 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>475992ed-0adf-48db-be7c-3f94f3e33a71</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>program.py</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <Name>NonPartitionedCollectionOperations</Name>
+    <RootNamespace>NonPartitionedCollectionOperations</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="program.py" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+  <!-- Uncomment the CoreCompile target to enable the Build command in
+       Visual Studio and specify your pre- and post-build commands in
+       the BeforeBuild and AfterBuild targets below. -->
+  <!--<Target Name="CoreCompile" />-->
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+</Project>

--- a/samples/NonPartitionedCollectionOperations/Program.py
+++ b/samples/NonPartitionedCollectionOperations/Program.py
@@ -141,7 +141,7 @@ class ItemManagement:
         print('\n1.2 Reading Item by Id\n')
 
         # Note that Reads require a partition key to be spcified.
-        response = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+        response = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
 
         print('Item read by Id {0}'.format(doc_id))
         print('Account Number: {0}'.format(response.get('account_number')))
@@ -180,7 +180,7 @@ class ItemManagement:
     def ReplaceItem(container, doc_id):
         print('\n1.5 Replace an Item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.replace_item(item=read_item, body=read_item)
 
@@ -190,7 +190,7 @@ class ItemManagement:
     def UpsertItem(container, doc_id):
         print('\n1.6 Upserting an item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.upsert_item(body=read_item)
 
@@ -200,7 +200,7 @@ class ItemManagement:
     def DeleteItem(container, doc_id):
         print('\n1.7 Deleting Item by Id\n')
 
-        response = container.delete_item(item=doc_id, partition_key=partition_key.Empty)
+        response = container.delete_item(item=doc_id, partition_key=partition_key.NonePk)
 
         print('Deleted item\'s Id is {0}'.format(doc_id))
 

--- a/samples/NonPartitionedCollectionOperations/Program.py
+++ b/samples/NonPartitionedCollectionOperations/Program.py
@@ -1,0 +1,316 @@
+import azure.cosmos.cosmos_client as cosmos_client
+import azure.cosmos.errors as errors
+import requests
+import six
+import json
+import uuid
+from six.moves.urllib.parse import quote as urllib_quote
+import azure.cosmos.auth as auth
+import azure.cosmos.partition_key as partition_key
+import datetime
+
+import samples.Shared.config as cfg
+
+# ----------------------------------------------------------------------------------------------------------
+# Prerequistes -
+#
+# 1. An Azure Cosmos account -
+#    https:#azure.microsoft.com/en-us/documentation/articles/documentdb-create-account/
+#
+# 2. Microsoft Azure Cosmos PyPi package -
+#    https://pypi.python.org/pypi/azure-cosmos/
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates the basic CRUD operations on a Item resource in a non partitioned container,
+# for Azure Cosmos using Python SDK > v4.0.0 with API version > 2018-12-31
+# ----------------------------------------------------------------------------------------------------------
+
+HOST = cfg.settings['host']
+MASTER_KEY = cfg.settings['master_key']
+DATABASE_ID = cfg.settings['database_id']
+CONTAINER_ID = cfg.settings['container_id']
+
+
+class IDisposable(cosmos_client.CosmosClient):
+    """ A context manager to automatically close an object with a close method
+    in a with statement. """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __enter__(self):
+        return self.obj  # bound to target
+
+    def __exit__(self, exception_type, exception_val, trace):
+        # extra cleanup in here
+        self = None
+
+
+class ItemManagement:
+    @staticmethod
+    def CreateNonPartitionedCollection(db):
+        # Create a non partitioned collection using the rest API and older version
+        client = requests.Session()
+        base_url_split = HOST.split(":");
+        resource_url = base_url_split[0] + ":" + base_url_split[1] + ":" + base_url_split[2].split("/")[
+            0] + "//dbs/" + db.id + "/colls/"
+        verb = "post"
+        resource_id_or_fullname = "dbs/" + db.id
+        resource_type = "colls"
+        data = '{"id":"mycoll"}'
+
+        headers = {}
+        headers["x-ms-version"] = "2018-09-17"
+        headers["x-ms-date"] = (datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT'))
+        headers['authorization'] = ItemManagement.get_authorization(db.client_connection, verb,
+                                                         resource_id_or_fullname, resource_type, headers)
+        response = client.request(verb,
+                                  resource_url,
+                                  data=data,
+                                  headers=headers,
+                                  timeout=60,
+                                  stream=False,
+                                  verify=False)
+
+        data = response.content
+        if not six.PY2:
+            # python 3 compatible: convert data from byte to unicode string
+            data = data.decode('utf-8')
+        data = json.loads(data)
+        created_collection = db.get_container(data['id'])
+
+        # Create a document in the non partitioned collection using the rest API and older version
+        resource_url = base_url_split[0] + ":" + base_url_split[1] + ":" + base_url_split[2].split("/")[0] \
+                       + "//dbs/" + db.id + "/colls/" + created_collection.id + "/docs/"
+        resource_id_or_fullname = "dbs/" + db.id + "/colls/" + created_collection.id
+        resource_type = "docs"
+        data = json.dumps(ItemManagement.GetSalesOrder('SaledOrder0'))
+
+        headers['authorization'] = ItemManagement.get_authorization(db.client_connection, verb,
+                                                         resource_id_or_fullname, resource_type, headers)
+        response = client.request(verb,
+                                  resource_url,
+                                  data=data,
+                                  headers=headers,
+                                  timeout=60,
+                                  stream=False,
+                                  verify=False)
+
+        data = response.content
+        if not six.PY2:
+            # python 3 compatible: convert data from byte to unicode string
+            data = data.decode('utf-8')
+        data = json.loads(data)
+        created_document = data
+        return created_collection, created_document
+
+    @staticmethod
+    def get_authorization(client, verb, resource_id_or_fullname, resource_type, headers):
+        authorization = auth.GetAuthorizationHeader(
+            cosmos_client_connection=client,
+            verb=verb,
+            path='',
+            resource_id_or_fullname=resource_id_or_fullname,
+            is_name_based=True,
+            resource_type=resource_type,
+            headers=headers)
+
+        # urllib.quote throws when the input parameter is None
+        if authorization:
+            # -_.!~*'() are valid characters in url, and shouldn't be quoted.
+            authorization = urllib_quote(authorization, '-_.!~*\'()')
+
+        return authorization
+
+    @staticmethod
+    def CreateItems(container):
+        print('Creating Items')
+        print('\n1.1 Create Item\n')
+
+        # Create a SalesOrder object. This object has nested properties and various types including numbers, DateTimes and strings.
+        # This can be saved as JSON as is without converting into rows/columns.
+        sales_order = ItemManagement.GetSalesOrder("SalesOrder1")
+        container.create_item(body=sales_order)
+
+        # As your app evolves, let's say your object has a new schema. You can insert SalesOrderV2 objects without any
+        # changes to the database tier.
+        sales_order2 = ItemManagement.GetSalesOrderV2("SalesOrder2")
+        container.create_item(body=sales_order2)
+
+    @staticmethod
+    def ReadItem(container, doc_id):
+        print('\n1.2 Reading Item by Id\n')
+
+        # Note that Reads require a partition key to be spcified.
+        response = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+
+        print('Item read by Id {0}'.format(doc_id))
+        print('Account Number: {0}'.format(response.get('account_number')))
+        print('Subtotal: {0}'.format(response.get('subtotal')))
+
+    @staticmethod
+    def ReadItems(container):
+        print('\n1.3 - Reading all items in a container\n')
+
+        # NOTE: Use MaxItemCount on Options to control how many items come back per trip to the server
+        #       Important to handle throttles whenever you are doing operations such as this that might
+        #       result in a 429 (throttled request)
+        item_list = list(container.list_items(max_item_count=10))
+
+        print('Found {0} items'.format(item_list.__len__()))
+
+        for doc in item_list:
+            print('Item Id: {0}'.format(doc.get('id')))
+
+    @staticmethod
+    def QueryItems(container, doc_id):
+        print('\n1.4 Querying for an  Item by Id\n')
+
+        # enable_cross_partition_query should be set to True as the collection is partitioned
+        items = list(container.query_items(
+            query="SELECT * FROM r WHERE r.id=@id",
+            parameters=[
+                {"name": "@id", "value": doc_id}
+            ],
+            enable_cross_partition_query=True
+        ))
+
+        print('Item queried by Id {0}'.format(items[0].get("id")))
+
+    @staticmethod
+    def ReplaceItem(container, doc_id):
+        print('\n1.5 Replace an Item\n')
+
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+        read_item['subtotal'] = read_item['subtotal'] + 1
+        response = container.replace_item(item=read_item, body=read_item)
+
+        print('Replaced Item\'s Id is {0}, new subtotal={1}'.format(response['id'], response['subtotal']))
+
+    @staticmethod
+    def UpsertItem(container, doc_id):
+        print('\n1.6 Upserting an item\n')
+
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.Empty)
+        read_item['subtotal'] = read_item['subtotal'] + 1
+        response = container.upsert_item(body=read_item)
+
+        print('Upserted Item\'s Id is {0}, new subtotal={1}'.format(response['id'], response['subtotal']))
+
+    @staticmethod
+    def DeleteItem(container, doc_id):
+        print('\n1.7 Deleting Item by Id\n')
+
+        response = container.delete_item(item=doc_id, partition_key=partition_key.Empty)
+
+        print('Deleted item\'s Id is {0}'.format(doc_id))
+
+    @staticmethod
+    def GetSalesOrder(item_id):
+        order1 = {'id': item_id,
+                  'account_number': 'Account1',
+                  'purchase_order_number': 'PO18009186470',
+                  'order_date': datetime.date(2005, 1, 10).strftime('%c'),
+                  'subtotal': 419.4589,
+                  'tax_amount': 12.5838,
+                  'freight': 472.3108,
+                  'total_due': 985.018,
+                  'items': [
+                      {'order_qty': 1,
+                       'product_id': 100,
+                       'unit_price': 418.4589,
+                       'line_price': 418.4589
+                       }
+                  ],
+                  'ttl': 60 * 60 * 24 * 30
+                  }
+
+        return order1
+
+    @staticmethod
+    def GetSalesOrderV2(item_id):
+        # notice new fields have been added to the sales order
+        order2 = {'id': item_id,
+                  'account_number': 'Account2',
+                  'purchase_order_number': 'PO15428132599',
+                  'order_date': datetime.date(2005, 7, 11).strftime('%c'),
+                  'due_date': datetime.date(2005, 7, 21).strftime('%c'),
+                  'shipped_date': datetime.date(2005, 7, 15).strftime('%c'),
+                  'subtotal': 6107.0820,
+                  'tax_amount': 586.1203,
+                  'freight': 183.1626,
+                  'discount_amt': 1982.872,
+                  'total_due': 4893.3929,
+                  'items': [
+                      {'order_qty': 3,
+                       'product_code': 'A-123',  # notice how in item details we no longer reference a ProductId
+                       'product_name': 'Product 1',  # instead we have decided to denormalise our schema and include
+                       'currency_symbol': '$',  # the Product details relevant to the Order on to the Order directly
+                       'currecny_code': 'USD',
+                       # this is a typical refactor that happens in the course of an application
+                       'unit_price': 17.1,
+                       # that would have previously required schema changes and data migrations etc.
+                       'line_price': 5.7
+                       }
+                  ],
+                  'ttl': 60 * 60 * 24 * 30
+                  }
+
+        return order2
+
+
+def run_sample():
+    with IDisposable(cosmos_client.CosmosClient(HOST, {'masterKey': MASTER_KEY})) as client:
+        try:
+            # setup database for this sample
+            try:
+                db = client.create_database(id=DATABASE_ID)
+
+            except errors.HTTPFailure as e:
+                if e.status_code == 409:
+                    pass
+                else:
+                    raise errors.HTTPFailure(e.status_code)
+
+            # setup container for this sample
+            try:
+                container, document = ItemManagement.CreateNonPartitionedCollection(db)
+                print('Container with id \'{0}\' created'.format(CONTAINER_ID))
+
+            except errors.HTTPFailure as e:
+                if e.status_code == 409:
+                    print('Container with id \'{0}\' was found'.format(CONTAINER_ID))
+                else:
+                    raise errors.HTTPFailure(e.status_code)
+
+            # Read Item created in non partitioned collection using older API version
+            ItemManagement.ReadItem(container, document['id'])
+            ItemManagement.CreateItems(container)
+            ItemManagement.ReadItems(container)
+            ItemManagement.QueryItems(container, 'SalesOrder1')
+            ItemManagement.ReplaceItem(container, 'SalesOrder1')
+            ItemManagement.UpsertItem(container, 'SalesOrder1')
+            ItemManagement.DeleteItem(container, 'SalesOrder1')
+
+            # cleanup database after sample
+            try:
+                client.delete_database(db)
+
+            except errors.CosmosError as e:
+                if e.status_code == 404:
+                    pass
+                else:
+                    raise errors.HTTPFailure(e.status_code)
+
+        except errors.HTTPFailure as e:
+            print('\nrun_sample has caught an error. {0}'.format(e.message))
+
+        finally:
+            print("\nrun_sample done")
+
+
+if __name__ == '__main__':
+    try:
+        run_sample()
+
+    except Exception as e:
+        print("Top level Error: args:{0}, message:N/A".format(e.args))

--- a/samples/NonPartitionedCollectionOperations/Program.py
+++ b/samples/NonPartitionedCollectionOperations/Program.py
@@ -141,7 +141,7 @@ class ItemManagement:
         print('\n1.2 Reading Item by Id\n')
 
         # Note that Reads require a partition key to be spcified.
-        response = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
+        response = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
 
         print('Item read by Id {0}'.format(doc_id))
         print('Account Number: {0}'.format(response.get('account_number')))
@@ -180,7 +180,7 @@ class ItemManagement:
     def ReplaceItem(container, doc_id):
         print('\n1.5 Replace an Item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.replace_item(item=read_item, body=read_item)
 
@@ -190,7 +190,7 @@ class ItemManagement:
     def UpsertItem(container, doc_id):
         print('\n1.6 Upserting an item\n')
 
-        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePk)
+        read_item = container.get_item(id=doc_id, partition_key=partition_key.NonePartitionKeyValue)
         read_item['subtotal'] = read_item['subtotal'] + 1
         response = container.upsert_item(body=read_item)
 
@@ -200,7 +200,7 @@ class ItemManagement:
     def DeleteItem(container, doc_id):
         print('\n1.7 Deleting Item by Id\n')
 
-        response = container.delete_item(item=doc_id, partition_key=partition_key.NonePk)
+        response = container.delete_item(item=doc_id, partition_key=partition_key.NonePartitionKeyValue)
 
         print('Deleted item\'s Id is {0}'.format(doc_id))
 

--- a/samples/NonPartitionedCollectionOperations/Program.py
+++ b/samples/NonPartitionedCollectionOperations/Program.py
@@ -1,3 +1,24 @@
+#The MIT License (MIT)
+#Copyright (c) 2018 Microsoft Corporation
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+
 import azure.cosmos.cosmos_client as cosmos_client
 import azure.cosmos.errors as errors
 import requests

--- a/samples/Shared/config.py
+++ b/samples/Shared/config.py
@@ -2,5 +2,5 @@ settings = {
     'host': '[YOUR ENDPOINT]',
     'master_key': '[YOUR KEY]',
     'database_id': 'pysamples',
-    'collection_id': 'data'
+    'container_id': 'data'
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,6 @@ import azure.cosmos.errors as errors
 from azure.cosmos.http_constants import StatusCodes
 
 database_ids_to_delete = []
-collection_id_to_delete = None
 
 @pytest.fixture(scope="session")
 def teardown(request):

--- a/test/partition_key_tests.py
+++ b/test/partition_key_tests.py
@@ -125,14 +125,14 @@ class PartitionKeyTests(unittest.TestCase):
         created_container = self.created_db.get_container(self.created_collection_id)
 
         # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
-        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.NonePk)
+        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], self.created_document['id'])
 
         document_definition = {'id': str(uuid.uuid4())}
         created_item = created_container.create_item(body=document_definition)
         self.assertEquals(created_item['id'], document_definition['id'])
 
-        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.NonePk)
+        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], created_item['id'])
 
         document_definition_for_replace = {'id': str(uuid.uuid4())}
@@ -143,7 +143,7 @@ class PartitionKeyTests(unittest.TestCase):
         self.assertEquals(upserted_item['id'], document_definition['id'])
 
         # one document was created during setup, one with create (which was replaced) and one with upsert
-        items = list(created_container.query_items("SELECT * from c", partition_key=partition_key.NonePk))
+        items = list(created_container.query_items("SELECT * from c", partition_key=partition_key.NonePartitionKeyValue))
         self.assertEquals(len(items), 3)
 
         document_created_by_sproc_id = 'testDoc'
@@ -163,17 +163,17 @@ class PartitionKeyTests(unittest.TestCase):
         created_sproc = created_container.scripts.create_stored_procedure(body=sproc)
 
         # Partiton Key value same as what is specified in the stored procedure body
-        result = created_container.scripts.execute_stored_procedure(id=created_sproc['id'], partition_key=partition_key.NonePk)
+        result = created_container.scripts.execute_stored_procedure(id=created_sproc['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEqual(result, 1)
 
         # 3 previous items + 1 created from the sproc
         items = list(created_container.list_items())
         self.assertEquals(len(items), 4)
 
-        created_container.delete_item(upserted_item['id'], partition_key=partition_key.NonePk)
-        created_container.delete_item(replaced_item['id'], partition_key=partition_key.NonePk)
-        created_container.delete_item(document_created_by_sproc_id, partition_key=partition_key.NonePk)
-        created_container.delete_item(self.created_document['id'], partition_key=partition_key.NonePk)
+        created_container.delete_item(upserted_item['id'], partition_key=partition_key.NonePartitionKeyValue)
+        created_container.delete_item(replaced_item['id'], partition_key=partition_key.NonePartitionKeyValue)
+        created_container.delete_item(document_created_by_sproc_id, partition_key=partition_key.NonePartitionKeyValue)
+        created_container.delete_item(self.created_document['id'], partition_key=partition_key.NonePartitionKeyValue)
 
         items = list(created_container.list_items())
         self.assertEquals(len(items), 0)
@@ -181,6 +181,7 @@ class PartitionKeyTests(unittest.TestCase):
     def test_multi_partition_collection_read_document_with_no_pk(self):
         document_definition = {'id': str(uuid.uuid4())}
         self.created_collection.create_item(body=document_definition)
-        read_item = self.created_collection.get_item(id=document_definition['id'], partition_key=partition_key.Undefined)
+        read_item = self.created_collection.get_item(id=document_definition['id'], partition_key=partition_key.NonePartitionKeyValue)
         self.assertEquals(read_item['id'], document_definition['id'])
+        self.created_collection.delete_item(item=document_definition['id'], partition_key=partition_key.NonePartitionKeyValue)
 

--- a/test/partition_key_tests.py
+++ b/test/partition_key_tests.py
@@ -32,6 +32,7 @@ import azure.cosmos.partition_key as partition_key
 import azure.cosmos.cosmos_client as cosmos_client
 import test.test_config as test_config
 
+
 @pytest.mark.usefixtures("teardown")
 class PartitionKeyTests(unittest.TestCase):
     """Tests to verify if non partitoned collections are properly accessed on migration with version 2018-12-31.
@@ -42,6 +43,7 @@ class PartitionKeyTests(unittest.TestCase):
     connectionPolicy = test_config._test_config.connectionPolicy
     client = cosmos_client.CosmosClient(host, {'masterKey': masterKey}, "Session", connectionPolicy)
     created_db = test_config._test_config.create_database_if_not_exist(client)
+    created_collection = test_config._test_config.create_multi_partition_collection_with_custom_pk_if_not_exist(client)
 
     @classmethod
     def tearDownClass(cls):
@@ -156,4 +158,10 @@ class PartitionKeyTests(unittest.TestCase):
 
         items = list(created_container.list_items())
         self.assertEquals(len(items), 0)
+
+    def test_multi_partition_collection_read_document_with_no_pk(self):
+        document_definition = {'id': str(uuid.uuid4())}
+        self.created_collection.create_item(body=document_definition)
+        read_item = self.created_collection.get_item(id=document_definition['id'], partition_key=partition_key.Empty)
+        self.assertEquals(read_item['id'], document_definition['id'])
 

--- a/test/partition_key_tests.py
+++ b/test/partition_key_tests.py
@@ -124,18 +124,15 @@ class PartitionKeyTests(unittest.TestCase):
     def test_non_partitioned_collection_operations(self):
         created_container = self.created_db.get_container(self.created_collection_id)
 
-        # systemKey:True must be set while reading non partitioned collection with v 2018-12-31 SDK
-        self.assertTrue(created_container.is_system_key)
-
         # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
-        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.Empty)
+        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.NonePk)
         self.assertEquals(read_item['id'], self.created_document['id'])
 
         document_definition = {'id': str(uuid.uuid4())}
         created_item = created_container.create_item(body=document_definition)
         self.assertEquals(created_item['id'], document_definition['id'])
 
-        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.Empty)
+        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.NonePk)
         self.assertEquals(read_item['id'], created_item['id'])
 
         document_definition_for_replace = {'id': str(uuid.uuid4())}
@@ -146,7 +143,7 @@ class PartitionKeyTests(unittest.TestCase):
         self.assertEquals(upserted_item['id'], document_definition['id'])
 
         # one document was created during setup, one with create (which was replaced) and one with upsert
-        items = list(created_container.query_items("SELECT * from c", partition_key=partition_key.Empty))
+        items = list(created_container.query_items("SELECT * from c", partition_key=partition_key.NonePk))
         self.assertEquals(len(items), 3)
 
         document_created_by_sproc_id = 'testDoc'
@@ -166,17 +163,17 @@ class PartitionKeyTests(unittest.TestCase):
         created_sproc = created_container.scripts.create_stored_procedure(body=sproc)
 
         # Partiton Key value same as what is specified in the stored procedure body
-        result = created_container.scripts.execute_stored_procedure(id=created_sproc['id'], partition_key=partition_key.Empty)
+        result = created_container.scripts.execute_stored_procedure(id=created_sproc['id'], partition_key=partition_key.NonePk)
         self.assertEqual(result, 1)
 
         # 3 previous items + 1 created from the sproc
         items = list(created_container.list_items())
         self.assertEquals(len(items), 4)
 
-        created_container.delete_item(upserted_item['id'], partition_key=partition_key.Empty)
-        created_container.delete_item(replaced_item['id'], partition_key=partition_key.Empty)
-        created_container.delete_item(document_created_by_sproc_id, partition_key=partition_key.Empty)
-        created_container.delete_item(self.created_document['id'], partition_key=partition_key.Empty)
+        created_container.delete_item(upserted_item['id'], partition_key=partition_key.NonePk)
+        created_container.delete_item(replaced_item['id'], partition_key=partition_key.NonePk)
+        created_container.delete_item(document_created_by_sproc_id, partition_key=partition_key.NonePk)
+        created_container.delete_item(self.created_document['id'], partition_key=partition_key.NonePk)
 
         items = list(created_container.list_items())
         self.assertEquals(len(items), 0)
@@ -184,6 +181,6 @@ class PartitionKeyTests(unittest.TestCase):
     def test_multi_partition_collection_read_document_with_no_pk(self):
         document_definition = {'id': str(uuid.uuid4())}
         self.created_collection.create_item(body=document_definition)
-        read_item = self.created_collection.get_item(id=document_definition['id'], partition_key=partition_key.Empty)
+        read_item = self.created_collection.get_item(id=document_definition['id'], partition_key=partition_key.Undefined)
         self.assertEquals(read_item['id'], document_definition['id'])
 

--- a/test/partition_key_tests.py
+++ b/test/partition_key_tests.py
@@ -1,0 +1,158 @@
+# The MIT License (MIT)
+# Copyright (c) 2014 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+import pytest
+import requests
+import datetime
+import six
+import json
+import uuid
+from six.moves.urllib.parse import quote as urllib_quote
+import azure.cosmos.auth as auth
+import azure.cosmos.partition_key as partition_key
+import azure.cosmos.cosmos_client as cosmos_client
+import test.test_config as test_config
+
+@pytest.mark.usefixtures("teardown")
+class PartitionKeyTests(unittest.TestCase):
+    """Tests to verify if non partitoned collections are properly accessed on migration with version 2018-12-31.
+    """
+
+    host = test_config._test_config.host
+    masterKey = test_config._test_config.masterKey
+    connectionPolicy = test_config._test_config.connectionPolicy
+    client = cosmos_client.CosmosClient(host, {'masterKey': masterKey}, "Session", connectionPolicy)
+    created_db = test_config._test_config.create_database_if_not_exist(client)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.created_db.delete_container(container=cls.created_collection_id)
+
+    @classmethod
+    def setUpClass(cls):
+        # Create a non partitioned collection using the rest API and older version
+        client = requests.Session()
+        base_url_split = cls.host.split(":");
+        resource_url = base_url_split[0] + ":" + base_url_split[1] + ":" + base_url_split[2].split("/")[0] + "//dbs/" + cls.created_db.id + "/colls/"
+        verb = "post"
+        resource_id_or_fullname = "dbs/" + cls.created_db.id
+        resource_type = "colls"
+        data = '{"id":"mycoll"}'
+
+        headers = {}
+        headers["x-ms-version"] = "2018-09-17"
+        headers["x-ms-date"] = (datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT'))
+        headers['authorization'] = cls.get_authorization(cls.created_db.client_connection, verb, resource_id_or_fullname, resource_type, headers)
+        response = client.request(verb,
+                                  resource_url,
+                                  data=data,
+                                  headers=headers,
+                                  timeout=60,
+                                  stream=False,
+                                  verify=False)
+
+        data = response.content
+        if not six.PY2:
+            # python 3 compatible: convert data from byte to unicode string
+            data = data.decode('utf-8')
+        data = json.loads(data)
+        cls.created_collection_id = data['id']
+
+        # Create a document in the non partitioned collection using the rest API and older version
+        resource_url = base_url_split[0] + ":" + base_url_split[1] + ":" + base_url_split[2].split("/")[0]\
+                       + "//dbs/" + cls.created_db.id + "/colls/" + cls.created_collection_id + "/docs/"
+        resource_id_or_fullname = "dbs/" + cls.created_db.id + "/colls/" + cls.created_collection_id
+        resource_type = "docs"
+        data = '{"id":"doc1"}'
+
+        headers['authorization'] = cls.get_authorization(cls.created_db.client_connection, verb,
+                                                         resource_id_or_fullname, resource_type, headers)
+        response = client.request(verb,
+                                  resource_url,
+                                  data=data,
+                                  headers=headers,
+                                  timeout=60,
+                                  stream=False,
+                                  verify=False)
+
+        data = response.content
+        if not six.PY2:
+            # python 3 compatible: convert data from byte to unicode string
+            data = data.decode('utf-8')
+        data = json.loads(data)
+        cls.created_document = data
+
+    @classmethod
+    def get_authorization(cls, client, verb, resource_id_or_fullname, resource_type, headers):
+        authorization = auth.GetAuthorizationHeader(
+            cosmos_client_connection=client,
+            verb=verb,
+            path='',
+            resource_id_or_fullname=resource_id_or_fullname,
+            is_name_based=True,
+            resource_type=resource_type,
+            headers=headers)
+
+        # urllib.quote throws when the input parameter is None
+        if authorization:
+            # -_.!~*'() are valid characters in url, and shouldn't be quoted.
+            authorization = urllib_quote(authorization, '-_.!~*\'()')
+
+        return authorization
+
+    def test_non_partitioned_collection_operations(self):
+        created_container = self.created_db.get_container(self.created_collection_id)
+
+        # systemKey:True must be set while reading non partitioned collection with v 2018-12-31 SDK
+        self.assertTrue(created_container.client_connection.is_system_key)
+
+        # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
+        read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.Empty)
+        self.assertEquals(read_item['id'], self.created_document['id'])
+
+        document_definition = {'id': str(uuid.uuid4())}
+        created_item = created_container.create_item(body=document_definition)
+        self.assertEquals(created_item['id'], document_definition['id'])
+
+        read_item = created_container.get_item(created_item['id'], partition_key=partition_key.Empty)
+        self.assertEquals(read_item['id'], created_item['id'])
+
+        document_definition_for_replace = {'id': str(uuid.uuid4())}
+        replaced_item = created_container.replace_item(created_item['id'], body=document_definition_for_replace)
+        self.assertEquals(replaced_item['id'], document_definition_for_replace['id'])
+
+        upserted_item = created_container.upsert_item(body=document_definition)
+        self.assertEquals(upserted_item['id'], document_definition['id'])
+
+        # one document was created during setup, one with create (which was replaced) and one with upsert
+        items = list(created_container.query_items("SELECT * from c", partition_key=partition_key.Empty))
+        self.assertEquals(len(items), 3)
+
+        items = list(created_container.list_items())
+        self.assertEquals(len(items), 3)
+
+        created_container.delete_item(upserted_item['id'], partition_key=partition_key.Empty)
+        created_container.delete_item(replaced_item['id'], partition_key=partition_key.Empty)
+        created_container.delete_item(self.created_document['id'], partition_key=partition_key.Empty)
+
+        items = list(created_container.list_items())
+        self.assertEquals(len(items), 0)

--- a/test/partition_key_tests.py
+++ b/test/partition_key_tests.py
@@ -123,7 +123,7 @@ class PartitionKeyTests(unittest.TestCase):
         created_container = self.created_db.get_container(self.created_collection_id)
 
         # systemKey:True must be set while reading non partitioned collection with v 2018-12-31 SDK
-        self.assertTrue(created_container.client_connection.is_system_key)
+        self.assertTrue(created_container.is_system_key)
 
         # Pass partitionKey.Empty as partition key to access documents from a single partition collection with v 2018-12-31 SDK
         read_item = created_container.get_item(self.created_document['id'], partition_key=partition_key.Empty)
@@ -156,3 +156,4 @@ class PartitionKeyTests(unittest.TestCase):
 
         items = list(created_container.list_items())
         self.assertEquals(len(items), 0)
+

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,7 +41,7 @@ class _test_config(object):
     host = os.getenv('ACCOUNT_HOST', 'https://localhost:443')
 
     connectionPolicy = documents.ConnectionPolicy()
-    connectionPolicy.DisableSSLVerification = True
+    connectionPolicy.DisableSSLVerification = True 
 
     global_host = '[YOUR_GLOBAL_ENDPOINT_HERE]'
     write_location_host = '[YOUR_WRITE_ENDPOINT_HERE]'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,7 +41,7 @@ class _test_config(object):
     host = os.getenv('ACCOUNT_HOST', 'https://localhost:443')
 
     connectionPolicy = documents.ConnectionPolicy()
-    connectionPolicy.DisableSSLVerification = True 
+    connectionPolicy.DisableSSLVerification = True
 
     global_host = '[YOUR_GLOBAL_ENDPOINT_HERE]'
     write_location_host = '[YOUR_WRITE_ENDPOINT_HERE]'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -38,7 +38,7 @@ class _test_config(object):
 
     #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Cosmos DB Emulator Key")]
     masterKey = os.getenv('ACCOUNT_KEY', 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==')
-    host = os.getenv('ACCOUNT_HOST', 'https://localhost:443')
+    host = os.getenv('ACCOUNT_HOST', 'https://localhost:443') 
 
     connectionPolicy = documents.ConnectionPolicy()
     connectionPolicy.DisableSSLVerification = True

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -38,7 +38,7 @@ class _test_config(object):
 
     #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Cosmos DB Emulator Key")]
     masterKey = os.getenv('ACCOUNT_KEY', 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==')
-    host = os.getenv('ACCOUNT_HOST', 'https://localhost:443') 
+    host = os.getenv('ACCOUNT_HOST', 'https://localhost:443')
 
     connectionPolicy = documents.ConnectionPolicy()
     connectionPolicy.DisableSSLVerification = True


### PR DESCRIPTION
- Added partitionKey.Empty to be used while reading, deleting or querying a non partitioned collection using API v 2018-12-31
- Added support for adding the right partition key for create, replace and upsert of documents into non partitioned containers using API v 2018-12-31
- Bumped API  version to 2018-12-31
- Added sample for above scenarios