### PR TITLE
Encode data to str/bytes inside _RequestBodyFromData

### DIFF
--- a/azure/cosmos/synchronized_request.py
+++ b/azure/cosmos/synchronized_request.py
@@ -63,9 +63,9 @@ def _RequestBodyFromData(data):
         json_dumped = json.dumps(data, separators=(',',':'))
 
         if six.PY2:
-            return json_dumped.decode('utf-8')
-        else:
             return json_dumped
+        else:
+            return json_dumped.encode('utf-8')
     return None
 
 


### PR DESCRIPTION
urllib3 requires a bytes-like body 
json.dumps for Python 2.* provide it by default , python 3 return Unicode string. 
related to issue https://github.com/Azure/azure-cosmos-python/issues/135