### PR TITLE
Fix package problem

### DIFF
--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## Changes in 3.1.3 : ##
+
+- Replace pkg_resource style namespace package with native(Python3) and pkgutil(Python2) style
+
 ## Changes in 3.1.2 : ##
 
 - Added suport for connection retry configuration

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("changelog.md", encoding="utf-8") as f:
     CHANGELOG = f.read()
 
 setup(name='azure-cosmos',
-      version='3.1.2',
+      version='3.1.3',
       description='Azure Cosmos Python SDK',
       long_description=README + "\n\n" + CHANGELOG,
       long_description_content_type="text/markdown",
@@ -34,4 +34,8 @@ setup(name='azure-cosmos',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules'
       ],
-      packages=setuptools.find_packages(exclude=['test', 'test.*']))
+      packages=setuptools.find_packages(exclude=['test', 'test.*', 'azure']),
+      extras_require={
+          ':python_version<"3.0"': ['azure-nspkg'],
+      },
+)


### PR DESCRIPTION
Current `azure-cosmos` will always write an `__init__.py` file under `azure` folder, which is not correct.

There is a guide [here ](https://github.com/Azure/azure-sdk-for-python/blob/master/doc/dev/packaging.md) to introduce how to package azure sdk.

This PR is to follow this guide.