### PR TITLE
Fix syntax warning in session.py

### DIFF
--- a/azure/cosmos/session.py
+++ b/azure/cosmos/session.py
@@ -183,7 +183,7 @@ class SessionContainer(object):
                 session_token = response_headers[http_constants.HttpHeaders.SessionToken]
 
         id_to_sessionlsn = {}
-        if session_token is not '':
+        if session_token != '':
             ''' extract id, lsn from the token. For p-collection,
             the token will be a concatenation of pairs for each collection'''
             token_pairs = session_token.split(',')


### PR DESCRIPTION
/usr/lib/python3/dist-packages/azure/cosmos/session.py:186: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if session_token is not '':